### PR TITLE
Load pretrained weights for all models

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,6 +39,7 @@ TRAIN:
   MIXED_PRECISION: false                         # Necessary for training with Tensor Cores
   N_FOLDS: 10
   MEMORY_LIMIT: 21672
+  USE_PRETRAINED: False
   DATA_AUG:
     ZOOM_RANGE: 0.1
     HORIZONTAL_FLIP: true

--- a/config.yml
+++ b/config.yml
@@ -20,7 +20,7 @@ PATHS:
   METRICS: './results/metrics/'
   EXPERIMENTS: './results/experiments/'
   EXPERIMENT_VISUALIZATIONS: './img/experiments/'
-  PRETRAINED_WEIGHTS: '20220917-152337'
+  PRETRAINED_WEIGHTS: 'B:\\Documents\\Work\\DeepBreathe\\projects\\ssl_ab\\backbones\\simclr\\20220918-120648_mobilenetv2'
 
 DATA:
   IMG_DIM: [128, 128]
@@ -29,12 +29,12 @@ DATA:
   CLASSES: ['a_lines', 'b_lines']   # Classes for binary classification
 
 TRAIN:
-  MODEL_DEF: 'cutoffvgg16'   # One of {'vgg16', 'mobilenetv2', 'xception', 'efficientnetb7', 'custom_resnetv2', 'cutoffvgg16'}
+  MODEL_DEF: 'mobilenetv2'   # One of {'vgg16', 'mobilenetv2', 'xception', 'efficientnetb7', 'custom_resnetv2', 'cutoffvgg16'}
   EXPERIMENT_TYPE: 'single_train'               # One of {'single_train', 'cross_validation', 'hparam_search'}
   SEED: 10001
   N_CLASSES: 2
   BATCH_SIZE: 256
-  EPOCHS: 15
+  EPOCHS: 30
   PATIENCE: 15
   MIXED_PRECISION: false                         # Necessary for training with Tensor Cores
   N_FOLDS: 10
@@ -59,11 +59,12 @@ CLIP_PREDICTION:
 
 HPARAMS:
   MOBILENETV2:
-    LR: 0.001
+    LR: 0.0001
     DROPOUT: 0.35
-    L2_LAMBDA: 0.0001
+    L2_LAMBDA: 0.001
     NODES_DENSE0: 32
-    FROZEN_LAYERS: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,16,17,18,19,20,21,22,23,24,25,26,26,27,28,29,30]
+    FREEZE_IDX: 116
+    CUTOFF_IDX: 115
   SHUFFLENETV2:
     LR: 0.1
     DROPOUT: 0.5
@@ -73,11 +74,11 @@ HPARAMS:
     DROPOUT: 0.5
     L2_LAMBDA: 0.01
     NODES_DENSE0: 64
-    FROZEN_LAYERS: []
+    FREEZE_IDX: -1
   XCEPTION:
     LR: 0.01
     DROPOUT: 0.5
-    FROZEN_LAYERS: []
+    FREEZE_IDX: -1
     L2_LAMBDA: 0.01
   BiTR50x1:
     #https://blog.tensorflow.org/2020/05/bigtransfer-bit-state-of-art-transfer-learning-computer-vision.html
@@ -88,7 +89,7 @@ HPARAMS:
     LR: 0.1
     DROPOUT: 0.5
     L2_LAMBDA: 0.01
-    FROZEN_LAYERS: []
+    FREEZE_IDX: -1
   CNN0:
     LR: 0.001
     DROPOUT: 0.35

--- a/config.yml
+++ b/config.yml
@@ -1,10 +1,10 @@
 PATHS:
-  CLIPS_TABLE: 'data/clips_by_patient_cropped.csv'
-  FRAME_TABLE: 'data/frames.csv'   # Path to all LUS frames in the dataset
+  CLIPS_TABLE: 'data/clips_by_patients_cropped.csv'
+  FRAME_TABLE: 'data/frames_actually_cropped.csv' #'data/frames.csv'   # Path to all LUS frames in the dataset
   DATABASE_QUERY: 'data/parenchymal_clips.csv'
   RAW_CLIPS: 'data/raw_clips/'
   MASKED_CLIPS: 'data/masked_clips/'
-  FRAMES: 'B:/Datasets/Ottawa/pure_and_muggle/frames/'
+  FRAMES: 'B:/Datasets/AB/data_actually_cropped'
   PARTITIONS: 'data/partitions/'
   TEST_DF: 'data/partitions/test_set_final.csv'
   EXT_VAL_CLIPS_TABLE: 'data/clips_by_patient_mini.csv'
@@ -20,6 +20,7 @@ PATHS:
   METRICS: './results/metrics/'
   EXPERIMENTS: './results/experiments/'
   EXPERIMENT_VISUALIZATIONS: './img/experiments/'
+  PRETRAINED_WEIGHTS: '20220917-152337'
 
 DATA:
   IMG_DIM: [128, 128]
@@ -30,13 +31,14 @@ DATA:
 TRAIN:
   MODEL_DEF: 'cutoffvgg16'   # One of {'vgg16', 'mobilenetv2', 'xception', 'efficientnetb7', 'custom_resnetv2', 'cutoffvgg16'}
   EXPERIMENT_TYPE: 'single_train'               # One of {'single_train', 'cross_validation', 'hparam_search'}
+  SEED: 10001
   N_CLASSES: 2
   BATCH_SIZE: 256
   EPOCHS: 15
   PATIENCE: 15
   MIXED_PRECISION: false                         # Necessary for training with Tensor Cores
   N_FOLDS: 10
-  MEMORY_LIMIT: 10240
+  MEMORY_LIMIT: 21672
   DATA_AUG:
     ZOOM_RANGE: 0.1
     HORIZONTAL_FLIP: true
@@ -44,13 +46,13 @@ TRAIN:
     HEIGHT_SHIFT_RANGE: 0.2
     SHEAR_RANGE: 10
     ROTATION_RANGE: 45
-    BRIGHTNESS_RANGE: [0.7, 1.3]
+    BRIGHTNESS_RANGE: 0.3
   HPARAM_SEARCH:
     N_EVALS: 10
     HPARAM_OBJECTIVE: 'auc'
 
 CLIP_PREDICTION:
-  ALGORITHM: 'average'       # One of "contiguous", "sliding_window" or "average"
+  ALGORITHM: 'contiguous'       # One of "contiguous", "sliding_window" or "average"
   CLASSIFICATION_THRESHOLD: 0.5
   CONTIGUITY_THRESHOLD: 4
   SLIDING_WINDOW: 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-tensorboard==2.4.1
-tensorflow==2.4.1
-tensorflow-addons==0.12.1
+tensorboard==2.10.0
+tensorflow==2.7.0
+tensorflow-addons==0.17.1
 opencv_python==4.2.0.34
 matplotlib==3.2.0
 pandas==1.2.3

--- a/src/data/build-dataset.py
+++ b/src/data/build-dataset.py
@@ -49,10 +49,13 @@ def create_image_dataset(query_df_path):
     clip_dfs = []
 
     for index, row in tqdm(query_df.iterrows()):
-        for mp4_file in glob.glob(row['Path'] + '.mp4'):
+        print(row['Path'])
+        #print(glob.glob(row['Path']))
+        for mp4_file in glob.glob(row['Path']):
             image_paths = mp4_to_images(mp4_file)  # Convert mp4 encounter file to image files
-            clip_df = pd.DataFrame({'Frame Path': image_paths, 'Patient': row['patient_id'], 'Class': row['class'],
-                                    'Class Name': cfg['DATA']['CLASSES'][row['class']]})
+            clip_df = pd.DataFrame({'Frame Path': image_paths, 'Class': row['class'],
+                                'Class Name': cfg['DATA']['CLASSES'][row['class']]})
+            print(clip_df.head())
             clip_dfs.append(clip_df)
     all_clips_df = pd.concat(clip_dfs, axis=0, ignore_index=True)
     all_clips_df.to_csv(cfg['PATHS']['FRAME_TABLE'], index=False)

--- a/src/data/build-dataset.py
+++ b/src/data/build-dataset.py
@@ -25,8 +25,6 @@ def mp4_to_images(mp4_path):
     mp4_filename = mp4_filename.split('.')[0]       # Strip file extension
 
     idx = 0
-    max_area = 0
-    max_area_id = 0
     image_paths = []
     while (True):
         ret, frame = vc.read()
@@ -50,7 +48,6 @@ def create_image_dataset(query_df_path):
 
     for index, row in tqdm(query_df.iterrows()):
         print(row['Path'])
-        #print(glob.glob(row['Path']))
         for mp4_file in glob.glob(row['Path']):
             image_paths = mp4_to_images(mp4_file)  # Convert mp4 encounter file to image files
             clip_df = pd.DataFrame({'Frame Path': image_paths, 'Class': row['class'],

--- a/src/data/preprocessor.py
+++ b/src/data/preprocessor.py
@@ -1,0 +1,100 @@
+import os
+
+import tensorflow as tf
+from tensorflow.keras.layers import Layer, RandomZoom, RandomTranslation, RandomRotation, RandomFlip
+import yaml
+
+cfg = yaml.full_load(open(os.getcwd() + "/config.yml", 'r'))
+
+class Preprocessor:
+    '''
+    Responsible for creating a TF dataset from frame filenames and corresponding labels. Includes data preprocessing
+    functionality, including resizing and data augmentation.
+    '''
+
+    def __init__(self, scale_fn=None):
+        '''
+        :param preprocess_fn: Model-specific preprocessing function
+        '''
+        self.batch_size = cfg['TRAIN']['BATCH_SIZE']
+        self.n_classes = len(cfg['DATA']['CLASSES'])
+        self.img_dir = cfg['PATHS']['FRAME_TABLE']
+        self.autotune = tf.data.AUTOTUNE
+        self.data_augmentation = tf.keras.Sequential([
+            RandomZoom(cfg['TRAIN']['DATA_AUG']['ZOOM_RANGE'], fill_mode='constant'),
+            RandomTranslation(cfg['TRAIN']['DATA_AUG']['HEIGHT_SHIFT_RANGE'],
+                              cfg['TRAIN']['DATA_AUG']['WIDTH_SHIFT_RANGE'], fill_mode='constant'),
+            RandomRotation(cfg['TRAIN']['DATA_AUG']['ROTATION_RANGE'], fill_mode='constant'),
+            RandomFlip("horizontal"),
+            RandomBrightness(factor=cfg['TRAIN']['DATA_AUG']['BRIGHTNESS_RANGE'])
+        ])
+        self.input_scaler = scale_fn
+
+    def prepare(self, ds, shuffle=False, augment=False):
+        '''
+        Maps a series of preprocessing functions to each item in a dataset
+        :param ds: A TF Dataset
+        :param shuffle: Flag indicating whether to shuffle the dataset
+        :type augment: Flag indicating whether to include data augmentation transformations
+        :return: The prepared TF dataset
+        '''
+
+        # Shuffle the dataset
+        if shuffle:
+            ds = ds.shuffle(len(ds))
+
+        # Load and resize images
+        ds = ds.map(self._parse_fn, num_parallel_calls=self.autotune)
+
+        # Batch the dataset
+        ds = ds.batch(self.batch_size)
+
+        # Conduct data augmentation transformations, if indicated
+        if augment:
+            ds = ds.map(lambda x, y: (self.data_augmentation(x, training=True), y), num_parallel_calls=self.autotune)
+
+        # Apply input scaler
+        if self.input_scaler is None:
+            ds = ds.map(lambda x, y: (x / 255., y), num_parallel_calls=self.autotune)
+        else:
+            ds = ds.map(lambda x, y: (self.input_scaler(x), y), num_parallel_calls=self.autotune)
+
+        # Apply buffered prefetching on dataset
+        return ds.prefetch(buffer_size=self.autotune)
+
+
+    def _parse_fn(self, filename, label):
+        '''
+        Parse image file and resize image. Produces a tuple consisting of a resized image and its corresponding label.
+        :param filename (str): File name of the image
+        :param label (int): Label assigned to the image
+        :return: (image, label) tuple consisting of the  resized image and its class
+        '''
+        image_str = tf.io.read_file(filename)
+        image_decoded = tf.image.decode_jpeg(image_str, channels=3)
+        image = tf.cast(image_decoded, tf.float32)
+        ohe_label = tf.one_hot(label, self.n_classes)
+        return tf.image.resize(image, cfg['DATA']['IMG_DIM']), ohe_label
+
+
+
+class RandomBrightness(Layer):
+    '''
+    A custom layer that applies a random brightness shift to an image
+    '''
+
+    def __init__(self, factor=0.5, **kwargs):
+        '''
+        :param factor: Absolute value of the maximum brightness shift, in [0, 1]
+        '''
+        super(RandomBrightness, self).__init__(**kwargs)
+        self.factor = factor
+
+    def call(self, inputs, training=True):
+        '''
+        Applies random brightness shift to input image
+        :param image: image tensor
+        :return: image tensor with random amount of brightness applied to it
+        '''
+        outputs = tf.image.stateless_random_brightness(inputs, self.factor, (123, 0))
+        return outputs

--- a/src/data/preprocessor.py
+++ b/src/data/preprocessor.py
@@ -2,6 +2,7 @@ import os
 
 import tensorflow as tf
 from tensorflow.keras.layers import Layer, RandomZoom, RandomTranslation, RandomRotation, RandomFlip
+from tensorflow.image import ResizeMethod
 import yaml
 
 cfg = yaml.full_load(open(os.getcwd() + "/config.yml", 'r'))
@@ -12,9 +13,10 @@ class Preprocessor:
     functionality, including resizing and data augmentation.
     '''
 
-    def __init__(self, scale_fn=None):
+    def __init__(self, scale_fn=None, resize_interpolation=ResizeMethod.NEAREST_NEIGHBOR):
         '''
-        :param preprocess_fn: Model-specific preprocessing function
+        :param scale_fn: Model-specific input scaling function
+        :param resize_interpolation: Interpolation method for image resizing
         '''
         self.batch_size = cfg['TRAIN']['BATCH_SIZE']
         self.n_classes = len(cfg['DATA']['CLASSES'])
@@ -29,6 +31,7 @@ class Preprocessor:
             RandomBrightness(factor=cfg['TRAIN']['DATA_AUG']['BRIGHTNESS_RANGE'])
         ])
         self.input_scaler = scale_fn
+        self.interpolation = resize_interpolation
 
     def prepare(self, ds, shuffle=False, augment=False):
         '''
@@ -74,7 +77,7 @@ class Preprocessor:
         image_decoded = tf.image.decode_jpeg(image_str, channels=3)
         image = tf.cast(image_decoded, tf.float32)
         ohe_label = tf.one_hot(label, self.n_classes)
-        return tf.image.resize(image, cfg['DATA']['IMG_DIM']), ohe_label
+        return tf.image.resize(image, cfg['DATA']['IMG_DIM'], method=self.interpolation), ohe_label
 
 
 

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -25,58 +25,22 @@ def AB_classifier_preprocess(image, preprocessing_fn):
     INPUT_SIZE = (128, 128)
 
     # Resize image
-    resized_image = cv2.resize(image[0], INPUT_SIZE, interpolation=cv2.INTER_LINEAR)
+    resized_image = cv2.resize(image[0], INPUT_SIZE, interpolation=cv2.INTER_NEAREST)
     resized_image = resized_image.reshape((1, INPUT_SIZE[0], INPUT_SIZE[1], N_CHANNELS))
 
     # Apply scaling function
     preprocessed_image = preprocessing_fn(resized_image)
     return preprocessed_image
 
-def view_classifier_preprocess(image):
-    '''
-    Given a masked ultrasound image, execute preprocessing steps specific to the view classifier. Specifically, the
-    image is resized to (128, 128) and zero-centered with respect to the ImageNet dataset. The result is an image that
-    is ready for the forward pass of the COVID-19 classifier.
-    :image (np.array): A masked image with shape (1, H, W, 3)
-    :return (np.array): Preprocessed image with shape (1, 128, 128, 3)
-    '''
-
-    N_CHANNELS = 3
-    INPUT_SIZE = (128, 128)
-
-    # Resize image
-    resized_image = cv2.resize(image[0], INPUT_SIZE, interpolation=cv2.INTER_LINEAR)
-    resized_image = resized_image.reshape((1, INPUT_SIZE[0], INPUT_SIZE[1], N_CHANNELS))
-
-    # Apply scaling function
-    preprocessed_image = resnet_50v2_preprocess(resized_image)
-    return preprocessed_image
-
-def covid_classifier_preprocess(image):
-    '''
-    Given a masked ultrasound image, execute preprocessing steps specific to the COVID-19 classifier. Specifically, the image
-    is resized to (600, 600) and scaled to [-1, 1]. Then it is 0-centered and subsequently divided by its standard
-    deviation.
-    :image (np.array): A masked image with shape (1, H, W, 3)
-    :return (np.array): Preprocessed image with shape (1, 128, 128, 3)
-    '''
-
-    N_CHANNELS = 3
-    INPUT_SIZE = (600, 600)
-
-    # Resize image
-    resized_image = cv2.resize(image[0], INPUT_SIZE, interpolation=cv2.INTER_LINEAR)
-    resized_image = resized_image.reshape((1, INPUT_SIZE[0], INPUT_SIZE[1], N_CHANNELS))
-
-    # Apply scaling function
-    preprocessed_image = xception_preprocess(resized_image)
-
-    # As in keras ImageDataGenerator, set samplewise mean to 0 and divide by standard deviation
-    preprocessed_image -= np.mean(preprocessed_image, keepdims=True)
-    preprocessed_image /= (np.std(preprocessed_image, keepdims=True) + 1e-6)
-    return preprocessed_image
 
 def predict_wavebase_mp4(model_path, mp4_path, preds_path):
+    '''
+    Mimics the process for producing frame-wise predictions on the WaveBase device.
+    :model_path (str): Path to saved model
+    :mp4_path (str): Path to mp4 file for prediction
+    :preds_path (str): Path to CSV file in which frame-wise predictions are saved
+    :return (np.array): Frame-wise prediction probabilities
+    '''
 
     model_ext = os.path.splitext(model_path)[1]
     vc = cv2.VideoCapture(mp4_path)
@@ -89,7 +53,8 @@ def predict_wavebase_mp4(model_path, mp4_path, preds_path):
         ret, frame = vc.read()
         if not ret:
             break
-        #frame[0:frame.shape[0]//8,:] = 0.
+        frame[0:50, 0:160] = 0
+        plt.imshow(frame)
         frame = np.expand_dims(frame, axis=0)
         preprocessed_frame = AB_classifier_preprocess(frame, vgg16_preprocess)
         if model_ext == '.onnx':
@@ -102,9 +67,4 @@ def predict_wavebase_mp4(model_path, mp4_path, preds_path):
     pred_df.to_csv(preds_path, index=False)
     return preds
 
-#model_path = 'results/models/cutoffvgg16_final_cropped.h5'
-model_path = 'results/models/ab_model_not_compiled/AB_classifier.onnx'
-mp4_path = 'C:/Users/Blake/Downloads/AB_test/demo.mp4'
-preds_path = 'C:/Users/Blake/Downloads/AB_test/demo.csv'
-preds = predict_wavebase_mp4(model_path, mp4_path, preds_path)
 

--- a/src/deploy.py
+++ b/src/deploy.py
@@ -24,7 +24,7 @@ def AB_classifier_preprocess(image, preprocessing_fn):
     N_CHANNELS = 3
     INPUT_SIZE = (128, 128)
 
-    # Resize image
+    # Resize image using the same interpolation method as was used during training
     resized_image = cv2.resize(image[0], INPUT_SIZE, interpolation=cv2.INTER_NEAREST)
     resized_image = resized_image.reshape((1, INPUT_SIZE[0], INPUT_SIZE[1], N_CHANNELS))
 

--- a/src/models/model_utils.py
+++ b/src/models/model_utils.py
@@ -1,0 +1,50 @@
+import tensorflow as tf
+from tensorflow.keras.layers import Activation, Conv2D, BatchNormalization
+
+def initialize_with_pretrained_weights(model, weights_path):
+    '''
+    Initializes the weights of a model using those saved at weights_path
+    :param model: A tf.keras model
+    :param weights_path: A path to serialized model weights
+    :return: A tf.keras model with weights initialized using pre-trained values
+    '''
+    pretrained = tf.keras.models.load_model(weights_path, compile=False)
+    for layer in pretrained.layers:
+        if layer.trainable:
+            model.get_layer(layer.name).set_weights(layer.get_weights())
+    return model
+
+
+# Skip Connector for custom ResNetV2
+def residual_block(X, num_filters: int, stride: int = 1, kernel_size: int = 3,
+                   activation: str = 'relu', bn: bool = True, conv_first: bool = True):
+    """
+    :param X: Tensor layer from previous layer
+    :param num_filers: integer, conv2d number of filters
+    :param stride: integer, default 1, stride square dimension
+    :param kernel_size: integer, default 3, conv2d square kernel dimensions
+    :param activation: string, default 'relu', activation function
+    :param bn: bool, default True, to use Batch Normalization
+    :param conv_first: bool, default True, conv-bn-activation (True) or bn-activation-conv (False)
+    """
+
+    conv_layer = Conv2D(num_filters,
+                        kernel_size=kernel_size,
+                        strides=stride,
+                        padding='same')
+    # X = input
+    if conv_first:
+        X = conv_layer(X)
+        if bn:
+            X = BatchNormalization()(X)
+        if activation is not None:
+            X = Activation(activation)(X)
+
+    else:
+        if bn:
+            X = BatchNormalization()(X)
+        if activation is not None:
+            X = Activation(activation)(X)
+        X = conv_layer(X)
+
+    return X

--- a/src/models/model_utils.py
+++ b/src/models/model_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import tensorflow as tf
 from tensorflow.keras.layers import Activation, Conv2D, BatchNormalization
 
@@ -8,6 +10,7 @@ def initialize_with_pretrained_weights(model, weights_path):
     :param weights_path: A path to serialized model weights
     :return: A tf.keras model with weights initialized using pre-trained values
     '''
+    assert os.path.exists(weights_path), f"Could not find model weights at file path: {weights_path}"
     pretrained = tf.keras.models.load_model(weights_path, compile=False)
     if pretrained.layers[0].name == "model":
         pretrained = pretrained.layers[0]
@@ -33,6 +36,7 @@ def freeze_layers(model,  freeze_cutoff, freeze_bn=True):
         elif freeze_bn and (('batch' in model.layers[i].name) or ('bn' in model.layers[i].name)):
             model.layers[i].trainable = False         # Freeze batch norm layers
         else:
+            model.layers[i].trainable = True
             print(f"Layer {i}: {model.layers[i].name} not frozen")
     return model
 

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -15,9 +15,12 @@ from tensorflow.keras.applications.xception import preprocess_input as xception_
 from tensorflow.keras.applications.efficientnet import preprocess_input as efficientnet_preprocess
 from tensorflow.keras.applications.resnet_v2 import preprocess_input as resnetv2_preprocess
 
+from src.models.model_utils import *
+
 def get_model(model_name):
     '''
     Return the model definition and associated preprocessing function as specified in the config file
+    :model_name: String identifier for a model architecture
     :return: (TF model definition function, preprocessing function)
     '''
 
@@ -44,7 +47,8 @@ def get_model(model_name):
         preprocessing_function = mobilenetv2_preprocess
     return model_def, preprocessing_function
 
-def mobilenetv2(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None):
+
+def mobilenetv2(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None, weights_path=None):
     '''
     Defines a model based on a pretrained MobileNetV2 for binary US classification.
     :param model_config: A dictionary of parameters associated with the model architecture
@@ -52,6 +56,7 @@ def mobilenetv2(model_config, input_shape, metrics, n_classes, mixed_precision=F
     :param metrics: Metrics to track model's performance
     :param mixed_precision: Whether to use mixed precision (use if you have GPU with compute capacity >= 7.0)
     :param output_bias: bias initializer of output layer
+    :param weights_path: path to pretrained weights
     :return: a Keras Model object with the architecture defined in this method
     '''
 
@@ -86,18 +91,20 @@ def mobilenetv2(model_config, input_shape, metrics, n_classes, mixed_precision=F
     # Add custom top layers
     X = GlobalAveragePooling2D()(X)
     X = Dropout(dropout)(X)
-    #X = Dense(fc0_nodes, activation='relu', activity_regularizer=l2(weight_decay), name='fc0')(X)
-    #X = Dropout(dropout)(X)
+    X = Dense(fc0_nodes, activation='relu', activity_regularizer=l2(weight_decay), name='fc0')(X)
+    X = Dropout(dropout)(X)
     X = Dense(n_classes, bias_initializer=output_bias, name='logits')(X)
     Y = Activation('softmax', dtype='float32', name='output')(X)
 
     # Set model loss function, optimizer, metrics.
     model = Model(inputs=X_input, outputs=Y)
+    if weights_path is not None:
+        model = initialize_with_pretrained_weights(model, weights_path)
     model.summary()
     model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=metrics)
     return model
     
-def vgg16(model_config, input_shape, metrics, n_classes, mixed_precision, output_bias=None):
+def vgg16(model_config, input_shape, metrics, n_classes, mixed_precision, output_bias=None, weights_path=None):
     '''
     Defines a model based on a pretrained VGG16 for binary US classification.
     :param model_config: A dictionary of parameters associated with the model architecture
@@ -105,6 +112,7 @@ def vgg16(model_config, input_shape, metrics, n_classes, mixed_precision, output
     :param metrics: Metrics to track model's performance
     :param mixed_precision: Whether to use mixed precision (use if you have GPU with compute capacity >= 7.0)
     :param output_bias: bias initializer of output layer
+    :param weights_path: path to pretrained weights
     :return: a Keras Model object with the architecture defined in this method
     '''
 
@@ -144,11 +152,13 @@ def vgg16(model_config, input_shape, metrics, n_classes, mixed_precision, output
 
     # Set model loss function, optimizer, metrics.
     model = Model(inputs=X_input, outputs=Y)
+    if weights_path is not None:
+        model = initialize_with_pretrained_weights(model, weights_path)
     model.summary()
     model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=metrics)
     return model
 
-def xception(model_config, input_shape, metrics, n_classes, mixed_precision, output_bias=None):
+def xception(model_config, input_shape, metrics, n_classes, mixed_precision, output_bias=None, weights_path=None):
     '''
     Defines a model based on a pretrained Xception for bianry US classification.
     :param model_config: A dictionary of parameters associated with the model architecture
@@ -156,15 +166,14 @@ def xception(model_config, input_shape, metrics, n_classes, mixed_precision, out
     :param metrics: Metrics to track model's performance
     :param mixed_precision: Whether to use mixed precision (use if you have GPU with compute capacity >= 7.0)
     :param output_bias: bias initializer of output layer
+    :param weights_path: path to pretrained weights
     :return: a Keras Model object with the architecture defined in this method
     '''
 
      # Set hyperparameters
     lr = model_config['LR']
     dropout = model_config['DROPOUT']
-    l2_lambda = model_config['L2_LAMBDA']
     optimizer = Adam(learning_rate=lr)
-    frozen_layers = model_config['FROZEN_LAYERS']
 
     print("MODEL CONFIG: ", model_config)
     
@@ -177,12 +186,7 @@ def xception(model_config, input_shape, metrics, n_classes, mixed_precision, out
     # Start with pretrained Xception
     X_input = Input(input_shape, name='input')
     base_model = Xception(include_top=False, weights='imagenet', input_shape=input_shape, input_tensor=X_input)
-    
-    # Freeze layers
-    '''
-    ADD FROZEN LAYERS HERE
-    '''
-    
+
     X = base_model.output
 
     # Add custom top layers
@@ -193,11 +197,13 @@ def xception(model_config, input_shape, metrics, n_classes, mixed_precision, out
 
     # Set model loss function, optimizer, metrics.
     model = Model(inputs=X_input, outputs=Y)
+    if weights_path is not None:
+        model = initialize_with_pretrained_weights(model, weights_path)
     model.summary()
     model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=metrics)
     return model
     
-def efficientnetb7(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None):
+def efficientnetb7(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None, weights_path=None):
     '''
      Defines a model based on a pretrained EfficientNetB7 for binary US classification.
     :param model_config: A dictionary of parameters associated with the model architecture
@@ -205,6 +211,7 @@ def efficientnetb7(model_config, input_shape, metrics, n_classes, mixed_precisio
     :param metrics: Metrics to track model's performance
     :param mixed_precision: Whether to use mixed precision (use if you have GPU with compute capacity >= 7.0)
     :param output_bias: bias initializer of output layer
+    :param weights_path: path to pretrained weights
     :return: a Keras Model object with the architecture defined in this method
     '''
 
@@ -227,12 +234,6 @@ def efficientnetb7(model_config, input_shape, metrics, n_classes, mixed_precisio
     X_input = Input(input_shape, name='input')
     base_model = EfficientNetB7(weights='imagenet', input_shape=input_shape, include_top=False, input_tensor=X_input)
 
-    # Freeze layers
-    # for layers in range(len(frozen_layers)):
-    #     layer2freeze = frozen_layers[layers]
-    #     print('Freezing layer: ' + str(layer2freeze))
-    #     base_model.layers[layer2freeze].trainable = False
-
     X = base_model.output
 
     # Add custom top layers
@@ -243,12 +244,14 @@ def efficientnetb7(model_config, input_shape, metrics, n_classes, mixed_precisio
 
     # Set model loss function, optimizer, metrics.
     model = Model(inputs=X_input, outputs=Y)
+    if weights_path is not None:
+        model = initialize_with_pretrained_weights(model, weights_path)
     model.summary()
     model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=metrics)
     return model
 
 
-def cnn0(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None):
+def cnn0(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None, weights_path=None):
     # Set hyperparameters
     nodes_dense0 = model_config['NODES_DENSE0']
     lr = model_config['LR']
@@ -292,45 +295,13 @@ def cnn0(model_config, input_shape, metrics, n_classes, mixed_precision=False, o
 
     # Set model loss function, optimizer, metrics.
     model = Model(inputs=X_input, outputs=Y)
+    if weights_path is not None:
+        model = initialize_with_pretrained_weights(model, weights_path)
     model.summary()
     model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=metrics)
     return model
 
-# Skip Connector for custom ResNetV2
-def residual_block(model_config, X, num_filters: int, stride: int = 1, kernel_size: int = 3,
-                   activation: str = 'relu', bn: bool = True, conv_first: bool = True):
-    """
-    :param X: Tensor layer from previous layer
-    :param num_filers: integer, conv2d number of filters
-    :param stride: integer, default 1, stride square dimension
-    :param kernel_size: integer, default 3, conv2d square kernel dimensions
-    :param activation: string, default 'relu', activation function
-    :param bn: bool, default True, to use Batch Normalization
-    :param conv_first: bool, default True, conv-bn-activation (True) or bn-activation-conv (False)
-    """
-
-    conv_layer = Conv2D(num_filters,
-                        kernel_size=kernel_size,
-                        strides=stride,
-                        padding='same')
-    # X = input
-    if conv_first:
-        X = conv_layer(X)
-        if bn:
-            X = BatchNormalization()(X)
-        if activation is not None:
-            X = Activation(activation)(X)
-
-    else:
-        if bn:
-            X = BatchNormalization()(X)
-        if activation is not None:
-            X = Activation(activation)(X)
-        X = conv_layer(X)
-
-    return X
-
-def custom_resnetv2(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None):
+def custom_resnetv2(model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None, weights_path=None):
     '''
      Defines a model based on a custom ResNetV2 for binary US classification.
     :param model_config: A dictionary of parameters associated with the model architecture
@@ -338,6 +309,7 @@ def custom_resnetv2(model_config, input_shape, metrics, n_classes, mixed_precisi
     :param metrics: Metrics to track model's performance
     :param mixed_precision: Whether to use mixed precision (use if you have GPU with compute capacity >= 7.0)
     :param output_bias: bias initializer of output layer
+    :param weights_path: path to pretrained weights
     :return: a Keras Model object with the architecture defined in this method
     '''
 
@@ -407,12 +379,12 @@ def custom_resnetv2(model_config, input_shape, metrics, n_classes, mixed_precisi
     # Model head
     X = SpatialDropout2D(dropout1)(X)
     X = GlobalAveragePooling2D(name='global_avgpool')(X)
-    #X = Dense(nodes_dense0, kernel_initializer='he_uniform', activity_regularizer=l2(l2_lambda), activation='relu',
-              #name='fc0')(X)
     Y = Dense(n_classes, activation='softmax', dtype='float32', name='output', bias_initializer=output_bias)(X)
 
     # Set model loss function, optimizer, metrics.
     model = Model(inputs=X_input, outputs=Y)
+    if weights_path is not None:
+        model = initialize_with_pretrained_weights(model, weights_path)
     model.summary()
     model.compile(loss='categorical_crossentropy', optimizer=optimizer, metrics=metrics, run_eagerly=True)
     return model
@@ -420,7 +392,8 @@ def custom_resnetv2(model_config, input_shape, metrics, n_classes, mixed_precisi
 
 class CutoffVGG16:
 
-    def __init__(self, model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None):
+    def __init__(self, model_config, input_shape, metrics, n_classes, mixed_precision=False, output_bias=None,
+                 weights_path=None):
         self.lr_extract = model_config['LR_EXTRACT']
         self.lr_finetune = model_config['LR_FINETUNE']
         self.dropout = model_config['DROPOUT']
@@ -434,6 +407,7 @@ class CutoffVGG16:
         self.input_shape = input_shape
         self.metrics = metrics
         self.mixed_precision = mixed_precision
+        self.weights_path = weights_path
         self.model = self.define_model()
 
     def define_model(self):
@@ -447,23 +421,23 @@ class CutoffVGG16:
         X = Dropout(self.dropout)(X)
         Y = Dense(self.n_classes, activation='softmax', bias_initializer=self.output_bias, name='output')(X)
         model = Model(inputs=X_input, outputs=Y)
+        if self.weights_path is not None:
+            model = initialize_with_pretrained_weights(model, self.weights_path)
         model.summary()
         return model
 
-    def fit(self, train_data, steps_per_epoch=None, epochs=1, validation_data=None, validation_steps=None,
-            callbacks=None, verbose=1, class_weight=None):
+    def fit(self, train_data, epochs=1, validation_data=None, callbacks=None, verbose=1, class_weight=None):
         for layer in self.vgg16_layers:
             layer.trainable = False
         self.model.compile(optimizer=self.optimizer_extract, loss='categorical_crossentropy', metrics=self.metrics, run_eagerly=True)
-        history_extract = self.model.fit(train_data, steps_per_epoch=steps_per_epoch, epochs=self.extract_epochs,
-                            validation_data=validation_data, validation_steps=validation_steps, callbacks=callbacks,
-                            verbose=verbose, class_weight=class_weight)
+        history_extract = self.model.fit(train_data, epochs=self.extract_epochs, validation_data=validation_data,
+                                         callbacks=callbacks, verbose=verbose, class_weight=class_weight)
         for layer in self.vgg16_layers[self.finetune_layer:]:
             layer.trainable = True
         self.model.compile(optimizer=self.optimizer_finetune, loss='categorical_crossentropy', metrics=self.metrics, run_eagerly=True)
-        history_finetune = self.model.fit(train_data, steps_per_epoch=steps_per_epoch, epochs=epochs, initial_epoch=history_extract.epoch[-1],
-                                      validation_data=validation_data, validation_steps=validation_steps, callbacks=callbacks,
-                                      verbose=verbose, class_weight=class_weight)
+        history_finetune = self.model.fit(train_data, epochs=epochs, initial_epoch=history_extract.epoch[-1],
+                                           validation_data=validation_data, callbacks=callbacks, verbose=verbose,
+                                          class_weight=class_weight)
 
     def evaluate(self, test_data, verbose=1):
         return self.model.evaluate(test_data, verbose=verbose)

--- a/src/train.py
+++ b/src/train.py
@@ -141,7 +141,8 @@ def log_test_results(model, test_set, test_df, test_metrics, log_dir):
     return
 
 
-def train_model(model_def, preprocessing_fn, train_df, val_df, test_df, hparams, save_weights=False, log_dir=None, verbose=True):
+def train_model(model_def, preprocessing_fn, train_df, val_df, test_df, hparams, pretrained_path=None,
+                save_weights=False, log_dir=None, verbose=True):
     '''
 
     :param model_def: Model definition function
@@ -150,6 +151,7 @@ def train_model(model_def, preprocessing_fn, train_df, val_df, test_df, hparams,
     :param val_df: Validation set of LUS frames
     :param test_df: Test set of LUS frames
     :param hparams: Dict of hyperparameters
+    :param pretrained_path: Path to pretrained weights. If None, trains the network from scratch.
     :param save_weights: Flag indicating whether to save the model's weights
     :param log_dir: TensorBoard logs directory
     :param verbose: Whether to print out all epoch details
@@ -192,7 +194,7 @@ def train_model(model_def, preprocessing_fn, train_df, val_df, test_df, hparams,
     # Define the model
     model = model_def(hparams, input_shape, metrics, cfg['TRAIN']['N_CLASSES'],
                       mixed_precision=cfg['TRAIN']['MIXED_PRECISION'], output_bias=output_bias,
-                      weights_path=cfg['PATHS']['PRETRAINED_WEIGHTS'])
+                      weights_path=pretrained_path)
 
     # Set training callbacks.
     callbacks = define_callbacks()
@@ -250,9 +252,12 @@ def train_single(hparams=None, save_weights=False, write_logs=False):
     if hparams is None:
         hparams = cfg['HPARAMS'][cfg['TRAIN']['MODEL_DEF'].upper()]
 
+    # Optionally get path to pretrained weights
+    pretrained_path = cfg['PATHS']['PRETRAINED_WEIGHTS'] if cfg['TRAIN']['USE_PRETRAINED'] else None
+
     # Train the model
     model, test_metrics, _ = train_model(model_def, preprocessing_fn, train_df, val_df, test_df, hparams,
-                                         save_weights=save_weights, log_dir=log_dir)
+                                         save_weights=save_weights, log_dir=log_dir, pretrained_path=pretrained_path)
     print('Test set metrics: ', test_metrics)
     return test_metrics, model
 


### PR DESCRIPTION
Several changes to the repository are included in this PR:
- loading pretrained weights from a specified path in the config file
- replacing ImageDataGenerator with tf.data datasets that use a custom preprocessing class
- a `deploy.py` script that can be used to replicate prediction on the WaveBase device